### PR TITLE
City damage meter enabled

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -97,7 +97,7 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2

--- a/Assets/Scripts/NPC/Operators/DamageDestructibleOperator.cs
+++ b/Assets/Scripts/NPC/Operators/DamageDestructibleOperator.cs
@@ -14,7 +14,7 @@ namespace Rioters.Operators {
                 // Setting animation
                 c.anim.SetBool("IsAttacking",true);
                 c.CurrentTarget.TakeDamage(Time.deltaTime * c.DPS);
-                //GameController.gameController.DamageCity(Time.deltaTime * c.DPS); // gameController has running total of damage dealt to city. Uncomment when implemented
+                GameController.instance.DamageCity(Time.deltaTime * c.DPS); // gameController has running total of damage dealt to city. Uncomment when implemented
 
                 // Check if totally destroyed
                 if ( c.CurrentTarget.IsDead || _attackTime >= c.MaxAttackActionLength ) {

--- a/Assets/Scripts/Selectable/Tooltip.cs
+++ b/Assets/Scripts/Selectable/Tooltip.cs
@@ -24,7 +24,8 @@ public class Tooltip : MonoBehaviour
 
     void Update()
     {
-        transform.position = Camera.main.WorldToScreenPoint(_destructible.anchorPoint.position);
+        if(_destructible)
+            transform.position = Camera.main.WorldToScreenPoint(_destructible.anchorPoint.position);
         SetHealthUI();
     }
 


### PR DESCRIPTION
Enabled city taking damage, fixed exception when destructible object destroyed while its tooltip was enabled